### PR TITLE
Add semester selection and printable fee receipts

### DIFF
--- a/DATABASE FILE/schoolfeesys.sql
+++ b/DATABASE FILE/schoolfeesys.sql
@@ -31,6 +31,7 @@ CREATE TABLE `fees_transaction` (
   `stdid` varchar(255) NOT NULL,
   `paid` int(255) NOT NULL,
   `submitdate` datetime NOT NULL,
+  `semester` varchar(50) NOT NULL,
   `transcation_remark` text NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -38,26 +39,26 @@ CREATE TABLE `fees_transaction` (
 -- Dumping data for table `fees_transaction`
 --
 
-INSERT INTO `fees_transaction` (`id`, `stdid`, `paid`, `submitdate`, `transcation_remark`) VALUES
-(6, '5', 1500, '2018-06-02 00:00:00', 'DEMO'),
-(11, '10', 2500, '2021-01-14 00:00:00', 'advance payment received'),
-(12, '11', 2100, '2021-03-26 00:00:00', 'Advance payment done!'),
-(13, '12', 3000, '2019-10-11 00:00:00', 'advance received'),
-(14, '13', 1000, '2021-04-01 00:00:00', 'advance received'),
-(15, '14', 2500, '2021-04-01 00:00:00', 'advance fee received first of month'),
-(16, '15', 2100, '2018-04-01 00:00:00', 'advance fee received march'),
-(17, '16', 2900, '2019-04-06 00:00:00', 'received during enrollment'),
-(18, '17', 3500, '2021-04-18 00:00:00', 'received on apr 18'),
-(19, '18', 500, '2021-01-03 00:00:00', 'none'),
-(20, '19', 4900, '2015-02-20 00:00:00', 'none'),
-(21, '20', 0, '2021-04-01 00:00:00', 'none'),
-(22, '21', 2000, '2021-04-04 00:00:00', 'none'),
-(23, '22', 0, '2021-02-21 00:00:00', 'none'),
-(24, '23', 5000, '2021-04-04 00:00:00', 'none'),
-(25, '24', 3900, '2021-03-29 00:00:00', 'advance payment received on march'),
-(26, '24', 3100, '2021-04-21 00:00:00', 'fees cleared up!'),
-(27, '22', 4900, '2021-04-23 00:00:00', 'all clear'),
-(28, '24', 900, '2021-04-23 00:00:00', 'cleared up remainings');
+INSERT INTO `fees_transaction` (`id`, `stdid`, `paid`, `submitdate`, `semester`, `transcation_remark`) VALUES
+(6, '5', 1500, '2018-06-02 00:00:00', '1', 'DEMO'),
+(11, '10', 2500, '2021-01-14 00:00:00', '1', 'advance payment received'),
+(12, '11', 2100, '2021-03-26 00:00:00', '1', 'Advance payment done!'),
+(13, '12', 3000, '2019-10-11 00:00:00', '1', 'advance received'),
+(14, '13', 1000, '2021-04-01 00:00:00', '1', 'advance received'),
+(15, '14', 2500, '2021-04-01 00:00:00', '1', 'advance fee received first of month'),
+(16, '15', 2100, '2018-04-01 00:00:00', '1', 'advance fee received march'),
+(17, '16', 2900, '2019-04-06 00:00:00', '1', 'received during enrollment'),
+(18, '17', 3500, '2021-04-18 00:00:00', '1', 'received on apr 18'),
+(19, '18', 500, '2021-01-03 00:00:00', '1', 'none'),
+(20, '19', 4900, '2015-02-20 00:00:00', '1', 'none'),
+(21, '20', 0, '2021-04-01 00:00:00', '1', 'none'),
+(22, '21', 2000, '2021-04-04 00:00:00', '1', 'none'),
+(23, '22', 0, '2021-02-21 00:00:00', '1', 'none'),
+(24, '23', 5000, '2021-04-04 00:00:00', '1', 'none'),
+(25, '24', 3900, '2021-03-29 00:00:00', '1', 'advance payment received on march'),
+(26, '24', 3100, '2021-04-21 00:00:00', '1', 'fees cleared up!'),
+(27, '22', 4900, '2021-04-23 00:00:00', '1', 'all clear'),
+(28, '24', 900, '2021-04-23 00:00:00', '1', 'cleared up remainings');
 
 -- --------------------------------------------------------
 
@@ -105,6 +106,7 @@ CREATE TABLE `student` (
   `contact` varchar(255) NOT NULL,
   `fees` int(255) NOT NULL,
   `grade` varchar(255) NOT NULL,
+  `semester` varchar(50) NOT NULL,
   `balance` int(255) NOT NULL,
   `delete_status` enum('0','1') NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -113,82 +115,70 @@ CREATE TABLE `student` (
 -- Dumping data for table `student`
 --
 
-INSERT INTO `student` (`id`, `emailid`, `sname`, `joindate`, `about`, `contact`, `fees`, `grade`, `balance`, `delete_status`) VALUES
-(5, 'christinemoore@gmail.com', 'Christine Moore', '2020-02-14 00:00:00', 'Demo About Text', '7566969650', 3660, '11', 2160, '0'),
-(10, 'leomaxwell@gmail.com', 'Leo Maxwell', '2021-01-14 00:00:00', 'new enrollment', '7563690002', 5120, '8', 2620, '0'),
-(11, 'arandrew@gmail.com', 'Andrew Arnette', '2021-03-26 00:00:00', 'new enrollment', '3520120006', 5200, '12', 3100, '0'),
-(12, 'jonathan@gmail.com', 'Jonathan Odell', '2019-10-11 00:00:00', 'old enrollment', '4230001205', 6900, '8', 3900, '0'),
-(13, 'benjamin@gmail.com', 'Benjamin L Russell', '2021-04-01 00:00:00', 'new enroll', '9012568500', 3600, '3', 2600, '0'),
-(14, 'kathrynmc@gmail.com', 'Kathryn McKeehan', '2021-04-01 00:00:00', 'new student from centrol branch', '9751250006', 5000, '10', 2500, '0'),
-(15, 'davidandersn@gmail.com', 'David Anderson', '2018-04-01 00:00:00', 'std from woodcreek branch', '7412036660', 7900, '7', 5800, '0'),
-(16, 'joannnt@gmail.com', 'Joann TSaylor', '2019-04-06 00:00:00', 'std from riverview branch', '9031480360', 6100, '12', 3200, '0'),
-(17, 'kevinrogers@gmail.com', 'Kevin Rogers', '2021-04-18 00:00:00', 'fresh enrollment', '9031476969', 5500, '11', 2000, '0'),
-(18, 'chavez.ly@gmail.com', 'Lyle Chavez', '2021-01-03 00:00:00', 'central student', '8520696976', 3600, '3', 3100, '0'),
-(20, 'none@dem.com', 'Demo', '2021-04-01 00:00:00', 'none', '785555555', 0, '1', 0, '1'),
-(21, 'marcellak@gmail.com', 'Marcella Keyes', '2021-04-04 00:00:00', 'fresh enrollment', '7456000020', 4900, '6', 2900, '0'),
-(22, 'george@gmail.com', 'George Russell', '2021-02-21 00:00:00', 'none', '2004568500', 4900, '5', 0, '0'),
-(23, 'willwilliams55@gmail.com', 'Will Williams', '2021-04-04 00:00:00', 'none', '8521245000', 12000, '11', 7000, '0'),
-(24, 'staceyellsw@gmail.com', 'Stacey Ellsworth', '2021-03-29 00:00:00', 'new enrollment', '6570002549', 7900, '10', 0, '0');
-
+INSERT INTO `student` (`id`, `emailid`, `sname`, `joindate`, `about`, `contact`, `fees`, `grade`, `semester`, `balance`, `delete_status`) VALUES
+(5, 'christinemoore@gmail.com', 'Christine Moore', '2020-02-14 00:00:00', 'Demo About Text', '7566969650', 3660, '11', '1', 2160, '0'),
+(10, 'leomaxwell@gmail.com', 'Leo Maxwell', '2021-01-14 00:00:00', 'new enrollment', '7563690002', 5120, '8', '1', 2620, '0'),
+(11, 'arandrew@gmail.com', 'Andrew Arnette', '2021-03-26 00:00:00', 'new enrollment', '3520120006', 5200, '12', '1', 3100, '0'),
+(12, 'jonathan@gmail.com', 'Jonathan Odell', '2019-10-11 00:00:00', 'old enrollment', '4230001205', 6900, '8', '1', 3900, '0'),
+(13, 'benjamin@gmail.com', 'Benjamin L Russell', '2021-04-01 00:00:00', 'new enroll', '9012568500', 3600, '3', '1', 2600, '0'),
+(14, 'kathrynmc@gmail.com', 'Kathryn McKeehan', '2021-04-01 00:00:00', 'new student from centrol branch', '9751250006', 5000, '10', '1', 2500, '0'),
+(15, 'davidandersn@gmail.com', 'David Anderson', '2018-04-01 00:00:00', 'std from woodcreek branch', '7412036660', 7900, '7', '1', 5800, '0'),
+(16, 'joannnt@gmail.com', 'Joann TSaylor', '2019-04-06 00:00:00', 'std from riverview branch', '9031480360', 6100, '12', '1', 3200, '0'),
+(17, 'kevinrogers@gmail.com', 'Kevin Rogers', '2021-04-18 00:00:00', 'fresh enrollment', '9031476969', 5500, '11', '1', 2000, '0'),
+(18, 'chavez.ly@gmail.com', 'Lyle Chavez', '2021-01-03 00:00:00', 'central student', '8520696976', 3600, '3', '1', 3100, '0'),
+(20, 'none@dem.com', 'Demo', '2021-04-01 00:00:00', 'none', '785555555', 0, '1', '1', 0, '1'),
+(21, 'marcellak@gmail.com', 'Marcella Keyes', '2021-04-04 00:00:00', 'fresh enrollment', '7456000020', 4900, '6', '1', 2900, '0'),
+(22, 'george@gmail.com', 'George Russell', '2021-02-21 00:00:00', 'none', '2004568500', 4900, '5', '1', 0, '0'),
+(23, 'willwilliams55@gmail.com', 'Will Williams', '2021-04-04 00:00:00', 'none', '8521245000', 12000, '11', '1', 7000, '0'),
+(24, 'staceyellsw@gmail.com', 'Stacey Ellsworth', '2021-03-29 00:00:00', 'new enrollment', '6570002549', 7900, '10', '1', 0, '0');
 -- --------------------------------------------------------
-
 --
 -- Table structure for table `user`
 --
-
 CREATE TABLE `user` (
-  `id` int(255) NOT NULL,
-  `username` varchar(255) NOT NULL,
-  `password` varchar(255) NOT NULL,
-  `name` varchar(255) NOT NULL,
-  `emailid` varchar(255) NOT NULL,
-  `lastlogin` datetime NOT NULL
+`id` int(255) NOT NULL,
+`username` varchar(255) NOT NULL,
+`password` varchar(255) NOT NULL,
+`name` varchar(255) NOT NULL,
+`emailid` varchar(255) NOT NULL,
+`lastlogin` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
 --
 -- Dumping data for table `user`
 --
-
 INSERT INTO `user` (`id`, `username`, `password`, `name`, `emailid`, `lastlogin`) VALUES
 (1, 'admin', '21232f297a57a5a743894a0e4a801fc3', 'Administrator', 'admin@gmail.com', '0000-00-00 00:00:00');
-
 --
 -- Indexes for dumped tables
 --
-
 --
 -- Indexes for table `fees_transaction`
 --
 ALTER TABLE `fees_transaction`
-  ADD PRIMARY KEY (`id`);
-
+ADD PRIMARY KEY (`id`);
 --
 -- Indexes for table `grade`
 --
 ALTER TABLE `grade`
-  ADD PRIMARY KEY (`id`);
-
+ADD PRIMARY KEY (`id`);
 --
 -- Indexes for table `student`
 --
 ALTER TABLE `student`
-  ADD PRIMARY KEY (`id`);
-
+ADD PRIMARY KEY (`id`);
 --
 -- Indexes for table `user`
 --
 ALTER TABLE `user`
-  ADD PRIMARY KEY (`id`);
-
+ADD PRIMARY KEY (`id`);
 --
 -- AUTO_INCREMENT for dumped tables
 --
-
 --
 -- AUTO_INCREMENT for table `fees_transaction`
 --
 ALTER TABLE `fees_transaction`
-  MODIFY `id` int(255) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=29;
+MODIFY `id` int(255) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=29;
 --
 -- AUTO_INCREMENT for table `grade`
 --

--- a/datatable.php
+++ b/datatable.php
@@ -1,376 +1,291 @@
-<?php
-include("php/dbconnect.php");
-include("php/checklogin.php");
-
-
 if($_GET['type']=="feesearch")
 {
-$aColumns = array( 's.id','s.sname','s.balance','s.fees','b.grade','s.contact','s.joindate');
-	
-	/* Indexed column (used for fast and accurate table cardinality) */
-	$sIndexColumn = "s.id";
-	
-	/* DB table to use */
-	$sTable = " student as s,grade as b ";
-	
-	
-	
-	/* 
-	 * Paging
-	 */
-	$sLimit = "";
-	if ( isset( $_GET['iDisplayStart'] ) && $_GET['iDisplayLength'] != '-1' )
-	{
-		$sLimit = "LIMIT ".mysqli_real_escape_string($conn,$_GET['iDisplayStart'] ).", ".
-			mysqli_real_escape_string($conn, $_GET['iDisplayLength'] );
-	}
-	
-	
-	/*
-	 * Ordering
-	 */
-	 $sOrder = "";
-	if ( isset( $_GET['iSortCol_0'] ) )
-	{
-		$sOrder = "ORDER BY  ";
-		for ( $i=0 ; $i<intval( $_GET['iSortingCols'] ) ; $i++ )
-		{
-			if ( $_GET[ 'bSortable_'.intval($_GET['iSortCol_'.$i]) ] == "true" )
-			{
-				$sOrder .= $aColumns[ intval( $_GET['iSortCol_'.$i] ) ]."
-				 	".mysqli_real_escape_string($conn, $_GET['sSortDir_'.$i] ) .", ";
-			}
-		}
-		
-		$sOrder = substr_replace( $sOrder, "", -2 );
-		if ( $sOrder == "ORDER BY" )
-		{
-			$sOrder = "";
-		}
-	}
-	
-	$cond = "";
-	$condArr = array();
-	if(isset($_GET['student']) && $_GET['student']!="")
-	{
-	$condArr[] = "s.sname like '%".mysqli_real_escape_string($conn,$_GET['student'])."%'";
-	
-	}
-	
-	if(isset($_GET['grade']) && $_GET['grade']!="")
-	{
-	$condArr[] = "b.id = '".mysqli_real_escape_string($conn,$_GET['grade'])."'";
-	
-	}
-	
-	
-	if(isset($_GET['doj']) && $_GET['doj']!="")
-	{
-	$Adate= explode(' ',$_GET['doj']);
-    $month = $Adate[0];
-    $year = $Adate[1];
-	$months = array('January'=>'01','February'=>'02','March'=>'03','April'=>'04','May'=>'05','June'=>'06','July'=>'07','August'=>'08','September'=>'09','October'=>'10','November'=>'11','December'=>'12');
-	
-	$doj = $months[$month].'-'.$year;	
-	$condArr[] = " DATE_FORMAT(s.joindate, '%m-%Y') = '".$doj."'";
-	
-	}
-	if(count($condArr)>0)
-	{
-	$cond = " and ( ".implode(" and ",$condArr)." )";
-	}
-	 
-	$mycount = count($aColumns);
-	 
-	$sWhere = " WHERE b.id=s.grade and s.delete_status='0' and s.balance>0 ";
-	if ( isset($_GET['sSearch'])&& $_GET['sSearch'] != "" )
-	{
-	    
-		$sWhere = $sWhere." and (";
-		for ( $i=0 ; $i<$mycount ; $i++ )
-		{
-		    
-			$sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn, $_GET['sSearch'] )."%' OR ";
-		}
-		$sWhere = substr_replace( $sWhere, "", -3 );
-		$sWhere .= ')';
-	}
-	
-	/* Individual column filtering 
-	for ( $i=0 ; $i<count($aColumns) ; $i++ )
-	{
-		if ( $_GET['bSearchable_'.$i] == "true" && $_GET['sSearch_'.$i] != '' )
-		{
-			if ( $sWhere == "" )
-			{
-				$sWhere = "WHERE ";
-			}
-			else
-			{
-				$sWhere .= " AND ";
-			}
-			$sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn,$_GET['sSearch_'.$i])."%' ";
-		}
-	}*/
-	
-	
-	/*
-	 * SQL queries
-	 * Get data to display
-	 */
-	$sQuery = "
-		SELECT SQL_CALC_FOUND_ROWS   ".implode(", ", $aColumns)."
-		FROM   ".$sTable."	".$sWhere.$cond." ".$sOrder." ".$sLimit;
-	
-	$rResult = $conn->query($sQuery) or die(mysqli_error($conn));
-	
-	/* Data set length after filtering */
-	$sQuery = "
-		SELECT FOUND_ROWS() as rr
-	";
-	$rResultFilterTotal = $conn->query( $sQuery) or die(mysqli_error($conn));
-	$aResultFilterTotal = $rResultFilterTotal->fetch_assoc();
-	$iFilteredTotal = $aResultFilterTotal['rr'];
-	
-	/* Total data set length */
-	$sQuery = "SELECT COUNT(".$sIndexColumn.") as cc
-		FROM   ".$sTable." WHERE b.id=s.grade and s.delete_status='0' and s.balance>0  ";
-	$rResultTotal = $conn->query( $sQuery ) or die(mysqli_error($conn));
-	$aResultTotal = $rResultTotal->fetch_assoc();
-	$iTotal = $aResultTotal['cc'];
-	
-	
-	/*
-	 * Output
-	 */
-	 
-	if(isset($_GET['sEcho'])) 
-	{
-	$output = array(
-		"sEcho" => intval($_GET['sEcho']),
-		"iTotalRecords" => $iTotal,
-		"iTotalDisplayRecords" => $iFilteredTotal,
-		"aaData" => array()
-	);
-	}else
-	{
-	 $output = array(
-		
-		"iTotalRecords" => $iTotal,
-		"iTotalDisplayRecords" => $iFilteredTotal,
-		"aaData" => array()
-	);
-	
-	}
-	
-     $row =array();
-	while ( $aRow = $rResult->fetch_assoc()  )
-	{
-		
-		
-		$row = array(
-                    html_entity_decode($aRow['sname'].'<br/>'.$aRow['contact']),
-                    $aRow['fees'],
-					$aRow['balance'],
-                    $aRow['grade'],
-					date("d M y", strtotime($aRow['joindate'])),
-                    
-					html_entity_decode('<button class="btn btn-success btn-sm" style="border-radius:0%" onclick="javascript:GetFeeForm('.$aRow['id'].')"><i class="fa fa-money"></i> Collect Fee </button>')
-										
-                );
-		
-		$output['aaData'][] =$row;
-		
-	}
-	
-	echo json_encode( $output );
+$aColumns = array( 's.sname','s.fees','s.balance','b.grade','s.semester','s.joindate','s.contact','s.id');
 
+/* Indexed column (used for fast and accurate table cardinality) */
+$sIndexColumn = "s.id";
+
+/* DB table to use */
+$sTable = " student as s,grade as b ";
+
+/*
+ * Paging
+ */
+$sLimit = "";
+if ( isset( $_GET['iDisplayStart'] ) && $_GET['iDisplayLength'] != '-1' )
+{
+        $sLimit = "LIMIT ".mysqli_real_escape_string($conn,$_GET['iDisplayStart'] ).", ".mysqli_real_escape_string($conn, $_GET['iDisplayLength'] );
 }
 
+/*
+ * Ordering
+ */
+ $sOrder = "";
+if ( isset( $_GET['iSortCol_0'] ) )
+{
+        $sOrder = "ORDER BY  ";
+        for ( $i=0 ; $i<intval( $_GET['iSortingCols'] ) ; $i++ )
+        {
+                if ( $_GET[ 'bSortable_'.intval($_GET['iSortCol_'.$i]) ] == "true" )
+                {
+                        $sOrder .= $aColumns[ intval( $_GET['iSortCol_'.$i] ) ]." ".mysqli_real_escape_string($conn, $_GET['sSortDir_'.$i] ) .", ";
+                }
+        }
 
+        $sOrder = substr_replace( $sOrder, "", -2 );
+        if ( $sOrder == "ORDER BY" )
+        {
+                $sOrder = "";
+        }
+}
+
+$cond = "";
+$condArr = array();
+if(isset($_GET['student']) && $_GET['student']!="")
+{
+$condArr[] = "s.sname like '%".mysqli_real_escape_string($conn,$_GET['student'])."%'";
+}
+
+if(isset($_GET['grade']) && $_GET['grade']!="")
+{
+$condArr[] = "b.id = '".mysqli_real_escape_string($conn,$_GET['grade'])."'";
+}
+
+if(isset($_GET['semester']) && $_GET['semester']!="")
+{
+$condArr[] = "s.semester = '".mysqli_real_escape_string($conn,$_GET['semester'])."'";
+}
+
+if(isset($_GET['doj']) && $_GET['doj']!="")
+{
+$Adate= explode(' ', $_GET['doj']);
+$month = $Adate[0];
+$year = $Adate[1];
+$months = array('January'=>'01','February'=>'02','March'=>'03','April'=>'04','May'=>'05','June'=>'06','July'=>'07','August'=>'08','September'=>'09','October'=>'10','November'=>'11','December'=>'12');
+
+$doj = $months[$month].'-'.$year;
+$condArr[] = " DATE_FORMAT(s.joindate, '%m-%Y') = '".$doj."'";
+}
+if(count($condArr)>0)
+{
+$cond = " and ( ".implode(" and ",$condArr)." )";
+}
+
+$mycount = count($aColumns);
+
+$sWhere = " WHERE b.id=s.grade and s.delete_status='0' and s.balance>0 ";
+if ( isset($_GET['sSearch'])&& $_GET['sSearch'] != "" )
+{
+        $sWhere = $sWhere." and (";
+        for ( $i=0 ; $i<$mycount ; $i++ )
+        {
+                $sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn, $_GET['sSearch'] )."%' OR ";
+        }
+        $sWhere = substr_replace( $sWhere, "", -3 );
+        $sWhere .= ')';
+}
+
+/*
+ * SQL queries
+ * Get data to display
+ */
+$sQuery = "
+        SELECT SQL_CALC_FOUND_ROWS   ".implode(", ", $aColumns).""
+        ." FROM   ".$sTable."      ".$sWhere.$cond." ".$sOrder." ".$sLimit;
+
+$rResult = $conn->query($sQuery) or die(mysqli_error($conn));
+
+/* Data set length after filtering */
+$sQuery = "SELECT FOUND_ROWS() as rr";
+$rResultFilterTotal = $conn->query( $sQuery) or die(mysqli_error($conn));
+$aResultFilterTotal = $rResultFilterTotal->fetch_assoc();
+$iFilteredTotal = $aResultFilterTotal['rr'];
+
+/* Total data set length */
+$sQuery = "SELECT COUNT(".$sIndexColumn.") as cc FROM   ".$sTable." WHERE b.id=s.grade and s.delete_status='0' and s.balance>0  ";
+$rResultTotal = $conn->query( $sQuery ) or die(mysqli_error($conn));
+$aResultTotal = $rResultTotal->fetch_assoc();
+$iTotal = $aResultTotal['cc'];
+
+/*
+ * Output
+ */
+if(isset($_GET['sEcho']))
+{
+$output = array(
+        "sEcho" => intval($_GET['sEcho']),
+        "iTotalRecords" => $iTotal,
+        "iTotalDisplayRecords" => $iFilteredTotal,
+        "aaData" => array()
+);
+}else
+{
+ $output = array(
+        "iTotalRecords" => $iTotal,
+        "iTotalDisplayRecords" => $iFilteredTotal,
+        "aaData" => array()
+ );
+}
+
+$row =array();
+while ( $aRow = $rResult->fetch_assoc()  )
+{
+        $row = array(
+            html_entity_decode($aRow['sname'].'<br/>'.$aRow['contact']),
+            $aRow['fees'],
+            $aRow['balance'],
+            $aRow['grade'],
+            $aRow['semester'],
+            date("d M y", strtotime($aRow['joindate'])),
+            html_entity_decode('<button class="btn btn-success btn-sm" style="border-radius:0%" onclick="javascript:GetFeeForm('.$aRow['id'].')"><i class="fa fa-money"></i> Collect Fee </button>')
+        );
+        $output['aaData'][] =$row;
+}
+echo json_encode( $output );
+}
 
 if($_GET['type']=="report")
 {
-$aColumns = array( 's.id','s.sname','s.balance','s.fees','b.grade','s.contact','s.joindate');
-	
-	/* Indexed column (used for fast and accurate table cardinality) */
-	$sIndexColumn = "s.id";
-	
-	/* DB table to use */
-	$sTable = " student as s,grade as b ";
-	
-	
-	
-	/* 
-	 * Paging
-	 */
-	$sLimit = "";
-	if ( isset( $_GET['iDisplayStart'] ) && $_GET['iDisplayLength'] != '-1' )
-	{
-		$sLimit = "LIMIT ".mysqli_real_escape_string($conn,$_GET['iDisplayStart'] ).", ".
-			mysqli_real_escape_string($conn, $_GET['iDisplayLength'] );
-	}
-	
-	
-	/*
-	 * Ordering
-	 */
-	 $sOrder = "";
-	if ( isset( $_GET['iSortCol_0'] ) )
-	{
-		$sOrder = "ORDER BY  ";
-		for ( $i=0 ; $i<intval( $_GET['iSortingCols'] ) ; $i++ )
-		{
-			if ( $_GET[ 'bSortable_'.intval($_GET['iSortCol_'.$i]) ] == "true" )
-			{
-				$sOrder .= $aColumns[ intval( $_GET['iSortCol_'.$i] ) ]."
-				 	".mysqli_real_escape_string($conn, $_GET['sSortDir_'.$i] ) .", ";
-			}
-		}
-		
-		$sOrder = substr_replace( $sOrder, "", -2 );
-		if ( $sOrder == "ORDER BY" )
-		{
-			$sOrder = "";
-		}
-	}
-	
-	$cond = "";
-	$condArr = array();
-	if(isset($_GET['student']) && $_GET['student']!="")
-	{
-	$condArr[] = "s.sname like '%".mysqli_real_escape_string($conn,$_GET['student'])."%'";
-	
-	}
-	
-	if(isset($_GET['grade']) && $_GET['grade']!="")
-	{
-	$condArr[] = "b.id = '".mysqli_real_escape_string($conn,$_GET['grade'])."'";
-	
-	}
-	
-	
-	if(isset($_GET['doj']) && $_GET['doj']!="")
-	{
-	$Adate= explode(' ',$_GET['doj']);
-    $month = $Adate[0];
-    $year = $Adate[1];
-	$months = array('January'=>'01','February'=>'02','March'=>'03','April'=>'04','May'=>'05','June'=>'06','July'=>'07','August'=>'08','September'=>'09','October'=>'10','November'=>'11','December'=>'12');
-	
-	$doj = $months[$month].'-'.$year;	
-	$condArr[] = " DATE_FORMAT(s.joindate, '%m-%Y') = '".$doj."'";
-	
-	}
-	if(count($condArr)>0)
-	{
-	$cond = " and ( ".implode(" and ",$condArr)." )";
-	}
-	 
-	$mycount = count($aColumns);
-	 
-	$sWhere = " WHERE b.id=s.grade and s.delete_status='0'  ";
-	if ( isset($_GET['sSearch'])&& $_GET['sSearch'] != "" )
-	{
-	    
-		$sWhere = $sWhere." and (";
-		for ( $i=0 ; $i<$mycount ; $i++ )
-		{
-		    
-			$sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn, $_GET['sSearch'] )."%' OR ";
-		}
-		$sWhere = substr_replace( $sWhere, "", -3 );
-		$sWhere .= ')';
-	}
-	
-	/* Individual column filtering 
-	for ( $i=0 ; $i<count($aColumns) ; $i++ )
-	{
-		if ( $_GET['bSearchable_'.$i] == "true" && $_GET['sSearch_'.$i] != '' )
-		{
-			if ( $sWhere == "" )
-			{
-				$sWhere = "WHERE ";
-			}
-			else
-			{
-				$sWhere .= " AND ";
-			}
-			$sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn,$_GET['sSearch_'.$i])."%' ";
-		}
-	}*/
-	
-	
-	/*
-	 * SQL queries
-	 * Get data to display
-	 */
-	$sQuery = "
-		SELECT SQL_CALC_FOUND_ROWS   ".implode(", ", $aColumns)."
-		FROM   ".$sTable."	".$sWhere.$cond." ".$sOrder." ".$sLimit;
-	
-	$rResult = $conn->query($sQuery) or die(mysqli_error($conn));
-	
-	/* Data set length after filtering */
-	$sQuery = "
-		SELECT FOUND_ROWS() as rr
-	";
-	$rResultFilterTotal = $conn->query( $sQuery) or die(mysqli_error($conn));
-	$aResultFilterTotal = $rResultFilterTotal->fetch_assoc();
-	$iFilteredTotal = $aResultFilterTotal['rr'];
-	
-	/* Total data set length */
-	$sQuery = "SELECT COUNT(".$sIndexColumn.") as cc
-		FROM   ".$sTable." WHERE b.id=s.grade and s.delete_status='0'   ";
-	$rResultTotal = $conn->query( $sQuery ) or die(mysqli_error($conn));
-	$aResultTotal = $rResultTotal->fetch_assoc();
-	$iTotal = $aResultTotal['cc'];
-	
-	
-	/*
-	 * Output
-	 */
-	 
-	if(isset($_GET['sEcho'])) 
-	{
-	$output = array(
-		"sEcho" => intval($_GET['sEcho']),
-		"iTotalRecords" => $iTotal,
-		"iTotalDisplayRecords" => $iFilteredTotal,
-		"aaData" => array()
-	);
-	}else
-	{
-	 $output = array(
-		
-		"iTotalRecords" => $iTotal,
-		"iTotalDisplayRecords" => $iFilteredTotal,
-		"aaData" => array()
-	);
-	
-	}
-	
-     $row =array();
-	while ( $aRow = $rResult->fetch_assoc()  )
-	{
-		
-		
-		$row = array(
-                    html_entity_decode($aRow['sname'].'<br/>'.$aRow['contact']),
-                    $aRow['fees'],
-					$aRow['balance'],
-                    $aRow['grade'],
-					date("d M y", strtotime($aRow['joindate'])),
-                    
-					html_entity_decode('<button class="btn btn-success btn-sm" style="border-radius:0%" onclick="javascript:GetFeeForm('.$aRow['id'].')"> Check Report </button>')
-										
-                );
-		
-		$output['aaData'][] =$row;
-		
-	}
-	
-	echo json_encode( $output );
+$aColumns = array( 's.sname','s.fees','s.balance','b.grade','s.semester','s.joindate','s.contact','s.id');
 
+/* Indexed column (used for fast and accurate table cardinality) */
+$sIndexColumn = "s.id";
+
+/* DB table to use */
+$sTable = " student as s,grade as b ";
+
+/*
+ * Paging
+ */
+$sLimit = "";
+if ( isset( $_GET['iDisplayStart'] ) && $_GET['iDisplayLength'] != '-1' )
+{
+        $sLimit = "LIMIT ".mysqli_real_escape_string($conn,$_GET['iDisplayStart'] ).", ".mysqli_real_escape_string($conn, $_GET['iDisplayLength'] );
 }
 
-?>
+/*
+ * Ordering
+ */
+ $sOrder = "";
+if ( isset( $_GET['iSortCol_0'] ) )
+{
+        $sOrder = "ORDER BY  ";
+        for ( $i=0 ; $i<intval( $_GET['iSortingCols'] ) ; $i++ )
+        {
+                if ( $_GET[ 'bSortable_'.intval($_GET['iSortCol_'.$i]) ] == "true" )
+                {
+                        $sOrder .= $aColumns[ intval( $_GET['iSortCol_'.$i] ) ]." ".mysqli_real_escape_string($conn, $_GET['sSortDir_'.$i] ) .", ";
+                }
+        }
+
+        $sOrder = substr_replace( $sOrder, "", -2 );
+        if ( $sOrder == "ORDER BY" )
+        {
+                $sOrder = "";
+        }
+}
+
+$cond = "";
+$condArr = array();
+if(isset($_GET['student']) && $_GET['student']!="")
+{
+$condArr[] = "s.sname like '%".mysqli_real_escape_string($conn,$_GET['student'])."%'";
+}
+
+if(isset($_GET['grade']) && $_GET['grade']!="")
+{
+$condArr[] = "b.id = '".mysqli_real_escape_string($conn,$_GET['grade'])."'";
+}
+
+if(isset($_GET['semester']) && $_GET['semester']!="")
+{
+$condArr[] = "s.semester = '".mysqli_real_escape_string($conn,$_GET['semester'])."'";
+}
+
+if(isset($_GET['doj']) && $_GET['doj']!="")
+{
+$Adate= explode(' ', $_GET['doj']);
+$month = $Adate[0];
+$year = $Adate[1];
+$months = array('January'=>'01','February'=>'02','March'=>'03','April'=>'04','May'=>'05','June'=>'06','July'=>'07','August'=>'08','September'=>'09','October'=>'10','November'=>'11','December'=>'12');
+
+$doj = $months[$month].'-'.$year;
+$condArr[] = " DATE_FORMAT(s.joindate, '%m-%Y') = '".$doj."'";
+}
+if(count($condArr)>0)
+{
+$cond = " and ( ".implode(" and ",$condArr)." )";
+}
+
+$mycount = count($aColumns);
+
+$sWhere = " WHERE b.id=s.grade and s.delete_status='0'  ";
+if ( isset($_GET['sSearch'])&& $_GET['sSearch'] != "" )
+{
+        $sWhere = $sWhere." and (";
+        for ( $i=0 ; $i<$mycount ; $i++ )
+        {
+                $sWhere .= $aColumns[$i]." LIKE '%".mysqli_real_escape_string($conn, $_GET['sSearch'] )."%' OR ";
+        }
+        $sWhere = substr_replace( $sWhere, "", -3 );
+        $sWhere .= ')';
+}
+
+/*
+ * SQL queries
+ * Get data to display
+ */
+$sQuery = "
+        SELECT SQL_CALC_FOUND_ROWS   ".implode(", ", $aColumns).""
+        ." FROM   ".$sTable."      ".$sWhere.$cond." ".$sOrder." ".$sLimit;
+
+$rResult = $conn->query($sQuery) or die(mysqli_error($conn));
+
+/* Data set length after filtering */
+$sQuery = "SELECT FOUND_ROWS() as rr";
+$rResultFilterTotal = $conn->query( $sQuery) or die(mysqli_error($conn));
+$aResultFilterTotal = $rResultFilterTotal->fetch_assoc();
+$iFilteredTotal = $aResultFilterTotal['rr'];
+
+/* Total data set length */
+$sQuery = "SELECT COUNT(".$sIndexColumn.") as cc FROM   ".$sTable." WHERE b.id=s.grade and s.delete_status='0'   ";
+$rResultTotal = $conn->query( $sQuery ) or die(mysqli_error($conn));
+$aResultTotal = $rResultTotal->fetch_assoc();
+$iTotal = $aResultTotal['cc'];
+
+/*
+ * Output
+ */
+if(isset($_GET['sEcho']))
+{
+$output = array(
+        "sEcho" => intval($_GET['sEcho']),
+        "iTotalRecords" => $iTotal,
+        "iTotalDisplayRecords" => $iFilteredTotal,
+        "aaData" => array()
+);
+}else
+{
+ $output = array(
+        "iTotalRecords" => $iTotal,
+        "iTotalDisplayRecords" => $iFilteredTotal,
+        "aaData" => array()
+ );
+}
+
+$row =array();
+while ( $aRow = $rResult->fetch_assoc()  )
+{
+        $row = array(
+            html_entity_decode($aRow['sname'].'<br/>'.$aRow['contact']),
+            $aRow['fees'],
+            $aRow['balance'],
+            $aRow['grade'],
+            $aRow['semester'],
+            date("d M y", strtotime($aRow['joindate'])),
+            html_entity_decode('<button class="btn btn-success btn-sm" style="border-radius:0%" onclick="javascript:GetFeeForm('.$aRow['id'].')"> Check Report </button>')
+        );
+        $output['aaData'][] =$row;
+}
+echo json_encode( $output );
+}

--- a/fees.php
+++ b/fees.php
@@ -6,6 +6,7 @@ if(isset($_POST['save']))
 {
 $paid = mysqli_real_escape_string($conn,$_POST['paid']);
 $submitdate = mysqli_real_escape_string($conn,$_POST['submitdate']);
+$semester = mysqli_real_escape_string($conn,$_POST['semester']);
 $transcation_remark = mysqli_real_escape_string($conn,$_POST['transcation_remark']);
 $sid = mysqli_real_escape_string($conn,$_POST['sid']);
 
@@ -15,8 +16,9 @@ $sr = $sq->fetch_assoc();
 $totalfee = $sr['fees'];
 if($sr['balance']>0)
 {
-$sql = "insert into fees_transaction(stdid,submitdate,transcation_remark,paid) values('$sid','$submitdate','$transcation_remark','$paid') ";
+$sql = "insert into fees_transaction(stdid,submitdate,semester,transcation_remark,paid) values('$sid','$submitdate','$semester','$transcation_remark','$paid') ";
 $conn->query($sql);
+$tid = $conn->insert_id;
 $sql = "SELECT sum(paid) as totalpaid FROM fees_transaction WHERE stdid = '$sid'";
 $tpq = $conn->query($sql);
 $tpr = $tpq->fetch_assoc();
@@ -26,7 +28,7 @@ $tbalance = $totalfee - $totalpaid;
 $sql = "update student set balance='$tbalance' where id = '$sid'";
 $conn->query($sql);
 
- echo '<script type="text/javascript">window.location="fees.php?act=1";</script>';
+ echo '<script type="text/javascript">window.location="receipt.php?tid=' . $tid . '";</script>';
 }
 }
 
@@ -121,7 +123,15 @@ include("php/header.php");
 									?>
 	</select>
   </div>
-  
+  <div class="form-group">
+    <label for="email"> Semester </label>
+    <select class="form-control" id="semester" name="semester">
+      <option value="">Select Semester</option>
+      <option value="1">First Semester</option>
+      <option value="2">Second Semester</option>
+    </select>
+  </div>
+
    <button type="button" class="btn btn-success btn-sm" style="border-radius:0%" id="find" > Filter </button>
   <button type="reset" class="btn btn-danger btn-sm" style="border-radius:0%" id="clear" > Reset </button>
 </form>
@@ -226,7 +236,7 @@ mydatatable();
 function mydatatable()
 {
         
-              $("#subjectresult").html('<table class="table table-striped table-bordered table-hover" id="tSortable22"><thead><tr><th>Name/Contact</th><th>Fees</th><th>Balance</th><th>Grade</th><th>DOJ</th><th>Action</th></tr></thead><tbody></tbody></table>');
+              $("#subjectresult").html('<table class="table table-striped table-bordered table-hover" id="tSortable22"><thead><tr><th>Name/Contact</th><th>Fees</th><th>Balance</th><th>Grade</th><th>Semester</th><th>DOJ</th><th>Action</th></tr></thead><tbody></tbody></table>');
 			  
 			    $("#tSortable22").dataTable({
 							      'sPaginationType' : 'full_numbers',
@@ -309,11 +319,12 @@ display:none;
                                     <thead>
                                         <tr>
                                           
-                                            <th>Name/Contact</th>                                            
+                                            <th>Name/Contact</th>
                                             <th>Fees</th>
-											<th>Balance</th>
-											<th>Grade</th>
-											<th>DOJ</th>
+                                                                                        <th>Balance</th>
+                                                                                        <th>Grade</th>
+                                                                                        <th>Semester</th>
+                                                                                        <th>DOJ</th>
 											<th>Action</th>
                                         </tr>
                                     </thead>

--- a/getfeeform.php
+++ b/getfeeform.php
@@ -46,6 +46,17 @@ echo '  <form class="form-horizontal" id ="signupForm1" action="fees.php" method
   
   
   <div class="form-group">
+    <label class="control-label col-sm-2" for="email">Semester:</label>
+    <div class="col-sm-10">
+      <select class="form-control" name="semester" id="semester">
+        <option value="">Select Semester</option>
+        <option value="1">First Semester</option>
+        <option value="2">Second Semester</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="form-group">
     <label class="control-label col-sm-2" for="email">Paid:</label>
     <div class="col-sm-10">
       <input type="text" class="form-control" name="paid"  id="paid"  />
@@ -94,7 +105,8 @@ $("#submitdate").datepicker( {
 
 $( "#signupForm1" ).validate( {
 				rules: {
-					submitdate: "required",
+                                        submitdate: "required",
+                                        semester: "required",
 					
 					paid: {
 						required: true,

--- a/inactivestd.php
+++ b/inactivestd.php
@@ -121,6 +121,7 @@ include("php/header.php");
                                             <th>#</th>
                                             <th>Name | Contact</th>
                                             <th>Grade</th>
+                                            <th>Semester</th>
                                             <th>Joined On</th>
                                             <th>Fees</th>
 											<th>Balance</th>
@@ -139,6 +140,7 @@ include("php/header.php");
                                             <td>'.$i.'</td>
                                             <td>'.$r['sname'].'<br/>'.$r['contact'].'</td>
                                             <td>'.$r['grade'].'</td>
+                                            <td>'.$r['semester'].'</td>
                                             <td>'.date("d M y", strtotime($r['joindate'])).'</td>
                                             <td>'.$r['fees'].'</td>
 											<td>'.$r['balance'].'</td>

--- a/receipt.php
+++ b/receipt.php
@@ -1,0 +1,68 @@
+<?php $page='receipt';
+include("php/dbconnect.php");
+include("php/checklogin.php");
+
+$tid = isset($_GET['tid']) ? mysqli_real_escape_string($conn,$_GET['tid']) : '';
+
+$sql = "SELECT ft.id, ft.submitdate, ft.semester, ft.transcation_remark, ft.paid, s.sname, s.contact, s.fees, s.balance, g.grade FROM fees_transaction ft JOIN student s ON s.id = ft.stdid JOIN grade g ON g.id = s.grade WHERE ft.id='$tid'";
+$q = $conn->query($sql);
+if(!$q || $q->num_rows == 0){
+    echo 'Invalid receipt request';
+    exit;
+}
+$res = $q->fetch_assoc();
+$semesterText = ($res['semester'] == 1) ? 'First Semester' : (($res['semester'] == 2) ? 'Second Semester' : '');
+?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>School Fees Management System</title>
+    <link href="css/bootstrap.css" rel="stylesheet" />
+    <link href="css/font-awesome.css" rel="stylesheet" />
+    <link href="css/basic.css" rel="stylesheet" />
+    <link href="css/custom.css" rel="stylesheet" />
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css' />
+</head>
+<?php include("php/header.php"); ?>
+<div id="page-wrapper">
+    <div id="page-inner">
+        <div class="row">
+            <div class="col-md-12">
+                <h1 class="page-head-line">Payment Receipt</h1>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        Receipt #<?php echo $res['id']; ?>
+                    </div>
+                    <div class="panel-body">
+                        <p><strong>Name:</strong> <?php echo $res['sname']; ?></p>
+                        <p><strong>Grade:</strong> <?php echo $res['grade']; ?></p>
+                        <p><strong>Contact:</strong> <?php echo $res['contact']; ?></p>
+                        <p><strong>Semester:</strong> <?php echo $semesterText; ?></p>
+                        <p><strong>Date:</strong> <?php echo $res['submitdate']; ?></p>
+                        <p><strong>Total Fee:</strong> <?php echo $res['fees']; ?></p>
+                        <p><strong>Amount Paid:</strong> <?php echo $res['paid']; ?></p>
+                        <p><strong>Remaining Balance:</strong> <?php echo $res['balance']; ?></p>
+                        <p><strong>Remark:</strong> <?php echo $res['transcation_remark']; ?></p>
+                    </div>
+                    <div class="panel-footer text-center">
+                        <button class="btn btn-success" onclick="window.print()">Print</button>
+                        <a href="fees.php" class="btn btn-default">Back</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="js/jquery-1.10.2.js"></script>
+<script src="js/bootstrap.js"></script>
+<script src="js/jquery.metisMenu.js"></script>
+<script src="js/custom1.js"></script>
+</body>
+</html>
+

--- a/report.php
+++ b/report.php
@@ -85,7 +85,15 @@ include("php/header.php");
 									?>
 	</select>
   </div>
-  
+  <div class="form-group">
+    <label for="email"> Semester </label>
+    <select class="form-control" id="semester" name="semester">
+      <option value="">Select Semester</option>
+      <option value="1">First Semester</option>
+      <option value="2">Second Semester</option>
+    </select>
+  </div>
+
    <button type="button" class="btn btn-success btn-sm" style="border-radius:0%" id="find" > Filter </button>
   <button type="reset" class="btn btn-danger btn-sm" style="border-radius:0%" id="clear" > Reset </button>
 </form>
@@ -190,7 +198,7 @@ mydatatable();
 function mydatatable()
 {
         
-              $("#subjectresult").html('<table class="table table-striped table-bordered table-hover" id="tSortable22"><thead><tr><th>Name/Contact</th><th>Fees</th><th>Balance</th><th>Grade</th><th>DOJ</th><th>Action</th></tr></thead><tbody></tbody></table>');
+              $("#subjectresult").html('<table class="table table-striped table-bordered table-hover" id="tSortable22"><thead><tr><th>Name/Contact</th><th>Fees</th><th>Balance</th><th>Grade</th><th>Semester</th><th>DOJ</th><th>Action</th></tr></thead><tbody></tbody></table>');
 			  
 			    $("#tSortable22").dataTable({
 							      'sPaginationType' : 'full_numbers',
@@ -277,6 +285,7 @@ display:none;
                                             <th>Fees</th>
                                           <th>Balance</th>
                                           <th>Grade</th>
+                                          <th>Semester</th>
                                           <th>DOJ</th>
                                           <th>Action</th>
                                         </tr>

--- a/student.php
+++ b/student.php
@@ -14,6 +14,7 @@ $balance = 0;
 $fees='';
 $about = '';
 $grade='';
+$semester='';
 
 
 if(isset($_POST['save']))
@@ -26,6 +27,7 @@ $contact = mysqli_real_escape_string($conn,$_POST['contact']);
 $about = mysqli_real_escape_string($conn,$_POST['about']);
 $emailid = mysqli_real_escape_string($conn,$_POST['emailid']);
 $grade = mysqli_real_escape_string($conn,$_POST['grade']);
+$semester = mysqli_real_escape_string($conn,$_POST['semester']);
 
 
  if($_POST['action']=="add")
@@ -35,11 +37,11 @@ $grade = mysqli_real_escape_string($conn,$_POST['grade']);
  $advancefees = mysqli_real_escape_string($conn,$_POST['advancefees']);
  $balance = $fees-$advancefees;
  
-  $q1 = $conn->query("INSERT INTO student (sname,joindate,contact,about,emailid,grade,balance,fees) VALUES ('$sname','$joindate','$contact','$about','$emailid','$grade','$balance','$fees')") ;
+  $q1 = $conn->query("INSERT INTO student (sname,joindate,contact,about,emailid,grade,semester,balance,fees) VALUES ('$sname','$joindate','$contact','$about','$emailid','$grade','$semester','$balance','$fees')") ;
   
   $sid = $conn->insert_id;
   
- $conn->query("INSERT INTO  fees_transaction (stdid,paid,submitdate,transcation_remark) VALUES ('$sid','$advancefees','$joindate','$remark')") ;
+ $conn->query("INSERT INTO  fees_transaction (stdid,paid,submitdate,semester,transcation_remark) VALUES ('$sid','$advancefees','$joindate','$semester','$remark')") ;
     
    echo '<script type="text/javascript">window.location="student.php?act=1";</script>';
  
@@ -47,7 +49,7 @@ $grade = mysqli_real_escape_string($conn,$_POST['grade']);
   if($_POST['action']=="update")
  {
  $id = mysqli_real_escape_string($conn,$_POST['id']);	
-   $sql = $conn->query("UPDATE  student  SET  grade  = '$grade', sname = '$sname', contact = '$contact', about = '$about', emailid = '$emailid'  WHERE  id  = '$id'");
+   $sql = $conn->query("UPDATE  student  SET  grade  = '$grade', semester = '$semester', sname = '$sname', contact = '$contact', about = '$about', emailid = '$emailid'  WHERE  id  = '$id'");
    echo '<script type="text/javascript">window.location="student.php?act=2";</script>';
  }
 
@@ -196,6 +198,16 @@ echo $errormsg;
 									</select>
 								</div>
 						</div>
+                                                <div class="form-group">
+                                                                <label class="col-sm-2 control-label" for="Old">Semester* </label>
+                                                                <div class="col-sm-10">
+                                                                        <select class="form-control" id="semester" name="semester">
+                                                                                <option value="">Select Semester</option>
+                                                                                <option value="1" <?php echo ($semester=='1')?'selected="selected"':'';?>>First Semester</option>
+                                                                                <option value="2" <?php echo ($semester=='2')?'selected="selected"':'';?>>Second Semester</option>
+                                                                        </select>
+                                                                </div>
+                                                </div>
 						
 						
 						<div class="form-group">
@@ -329,6 +341,7 @@ yearRange: "1970:<?php echo date('Y');?>"
 					joindate: "required",
 					emailid: "email",
 					grade: "required",
+                                        semester: "required",
 					
 					
 					contact: {
@@ -360,6 +373,7 @@ yearRange: "1970:<?php echo date('Y');?>"
 					joindate: "required",
 					emailid: "email",
 					grade: "required",
+                                        semester: "required",
 					
 					
 					contact: {
@@ -481,6 +495,7 @@ yearRange: "1970:<?php echo date('Y');?>"
                                             <th>#</th>
                                             <th>Name | Contact</th>
 											<th>Grade</th>
+                                            <th>Semester</th>
                                             <th>Joined On</th>
                                             <th>Fees</th>
 											<th>Balance</th>
@@ -499,6 +514,7 @@ yearRange: "1970:<?php echo date('Y');?>"
                                             <td>'.$i.'</td>
 											<td>'.$r['sname'].'<br/>'.$r['contact'].'</td>
 											<td>'.$r['grade'].''.'</td>
+                                            <td>'.$r['semester'].'</td>
                                             <td>'.date("d M y", strtotime($r['joindate'])).'</td>
                                             <td>'.$r['fees'].'</td>
 											<td>'.$r['balance'].'</td>


### PR DESCRIPTION
## Summary
- track semester in database for students and fee transactions
- expose semester options in student forms, fee collection, reports, and tables
- support semester filtering in datatable backend
- redirect fee submissions to a printable receipt page summarizing payment details

## Testing
- `php -l student.php && php -l fees.php && php -l report.php && php -l getfeeform.php && php -l datatable.php && php -l inactivestd.php && php -l receipt.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3d912448326a4c2da3dfbe8c79d